### PR TITLE
Added ctrl key check

### DIFF
--- a/lib/templates/plugin.js
+++ b/lib/templates/plugin.js
@@ -9,7 +9,7 @@ export default ({ app: { router } }) => {
         const href = event.currentTarget.getAttribute('href')
         if (href && href[0] === '/') {
           event.preventDefault()
-          event.metaKey
+          event.metaKey || event.ctrlKey
             ? window.open(href, '_blank', 'noopener')
             : router.push(href)
         }


### PR DESCRIPTION
"Meta key + click" opens page in new tab on Mac only. For Windows and Linux "Ctrl key + click" would be used.